### PR TITLE
Added function save_results

### DIFF
--- a/benchmark/save_results.py
+++ b/benchmark/save_results.py
@@ -1,0 +1,98 @@
+import json
+import csv
+from pathlib import Path
+from datetime import datetime
+
+
+def save_results(
+    results,
+    method,
+    task,
+    seed,
+    save_dir="results",
+    file_format="json",
+    **kwargs,
+):
+    """
+    Save benchmark results as JSON or CSV.
+
+    Args:
+        results (dict): Benchmark results as {metric_name (str): score (float or int)}
+                        (e.g.: {"C2ST": 0.84, "runtime_sec": 123.5}, ...).
+        method (str): Inference algorithm name (e.g.: "REJ_ABC", "nNLE", ...).
+        task (str): Benchmark task name (e.g.: "two_moons", "gaussian_linear", ...).
+        seed (int): Random seed used.
+        save_dir (str, optional): Output directory (default "results").
+        file_format (str, optional): "json" or "csv" (default "json").
+        **kwargs: Additional metadata to include.
+    """
+
+    # --- Input type validation ---
+    if not isinstance(method, str):
+        raise TypeError(f"Expected 'method' to be str, got {type(method).__name__}")
+    if not isinstance(task, str):
+        raise TypeError(f"Expected 'task' to be str, got {type(task).__name__}")
+    if not isinstance(seed, int):
+        raise TypeError(f"Expected 'seed' to be int, got {type(seed).__name__}")
+    if not isinstance(save_dir, (str, Path)):
+        raise TypeError(
+            f"Expected 'save_dir' to be a str or Path, got {type(save_dir).__name__}"
+        )
+    if not isinstance(file_format, str):
+        raise TypeError(
+            f"Expected 'file_format' to be str, got {type(file_format).__name__}"
+        )
+
+    file_format = file_format.lower()  # allow "JSON", "Csv", etc.
+    if file_format not in {"json", "csv"}:
+        raise ValueError(f"Unsupported file format: {file_format}. Use 'json' or 'csv'.")
+
+    # --- Prepare save location and filename ---
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    base = f"{method}__{task}__seed{seed}"
+    filename = f"{base}.{file_format}"
+    filepath = save_dir / filename
+
+    # if this exact filename exists, append __runN
+    if filepath.exists():
+        run_id = 1
+        while True:
+            filename = f"{base}__run{run_id}.{file_format}"
+            filepath = save_dir / filename
+            if not filepath.exists():
+                break
+            run_id += 1
+
+    # universal timestamp
+    timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
+
+    # --- Write out ---
+    if file_format == "json":
+        output = {
+            "method": method,
+            "task": task,
+            "seed": seed,
+            "timestamp": timestamp,
+            **kwargs,
+            "metrics": results,
+        }
+        with open(filepath, "w") as f:
+            json.dump(output, f, indent=4)
+
+    else:  # csv
+        row = {
+            "method": method,
+            "task": task,
+            "seed": seed,
+            "timestamp": timestamp,
+            **kwargs,
+            **results,
+        }
+        with open(filepath, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=row.keys())
+            writer.writeheader()
+            writer.writerow(row)
+
+    print(f"Results saved to {filepath.resolve()}")

--- a/tests/test_save_results.py
+++ b/tests/test_save_results.py
@@ -1,0 +1,99 @@
+import json
+import csv
+import pytest
+
+from benchmark.save_results import save_results
+
+
+def test_json_output(tmp_path):
+    metrics = {"test_metric_a1": 1.23, "test_metric_b1": 4}
+    method = "test_method1"
+    task = "test_task1"
+    seed = 0
+    save_dir = tmp_path / "results"
+
+    # Write JSON
+    save_results(metrics, method, task, seed, save_dir=save_dir, file_format="json")
+    file_path = save_dir / f"{method}__{task}__seed{seed}.json"
+
+    # File should exist
+    assert file_path.exists()
+
+    # Load and verify contents
+    with open(file_path, "r") as f:
+        data = json.load(f)
+
+    assert data["method"] == method
+    assert data["task"] == task
+    assert data["seed"] == seed
+    # timestamp present and ISO-format
+    assert isinstance(data["timestamp"], str) and "T" in data["timestamp"]
+    assert data["metrics"] == metrics
+
+
+def test_csv_output(tmp_path):
+    metrics = {"test_metric_a2": 1.0, "test_metric_b2": 0.5}
+    method = "test_method2"
+    task = "test_task2"
+    seed = 1
+    save_dir = tmp_path / "results"
+
+    # Write CSV
+    save_results(metrics, method, task, seed, save_dir=save_dir, file_format="csv")
+    file_path = save_dir / f"{method}__{task}__seed{seed}.csv"
+
+    # File should exist
+    assert file_path.exists()
+
+    # Read back with DictReader
+    with open(file_path, newline="") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+
+    assert row["method"] == method
+    assert row["task"] == task
+    assert int(row["seed"]) == seed
+    # Metrics come back as strings; convert to float
+    assert abs(float(row["test_metric_a2"]) - metrics["test_metric_a2"]) < 1e-8
+    assert abs(float(row["test_metric_b2"]) - metrics["test_metric_b2"]) < 1e-8
+
+
+def test_run_id_generation(tmp_path):
+    metrics = {"test_metric_a3": 22.5, "test_metric_b3": 12.1}
+    method = "test_method3"
+    task = "test_task3"
+    seed = 2
+    save_dir = tmp_path / "results"
+
+    # First call writes base filename
+    save_results(metrics, method, task, seed, save_dir=save_dir, file_format="json")
+    base = save_dir / f"{method}__{task}__seed{seed}.json"
+    assert base.exists()
+
+    # Second call causes __run1
+    save_results(metrics, method, task, seed, save_dir=save_dir, file_format="json")
+    run1 = save_dir / f"{method}__{task}__seed{seed}__run1.json"
+    assert run1.exists()
+
+    # Third call causes __run2
+    save_results(metrics, method, task, seed, save_dir=save_dir, file_format="json")
+    run2 = save_dir / f"{method}__{task}__seed{seed}__run2.json"
+    assert run1.exists()
+
+
+def test_input_validation(tmp_path):
+    # method must be str
+    with pytest.raises(TypeError):
+        save_results({}, 123, "t", 0, save_dir=tmp_path)
+
+    # task must be str
+    with pytest.raises(TypeError):
+        save_results({}, "m", 456, 0, save_dir=tmp_path)
+
+    # seed must be int
+    with pytest.raises(TypeError):
+        save_results({}, "m", "t", "zero", save_dir=tmp_path)
+
+    # file_format must be json or csv
+    with pytest.raises(ValueError):
+        save_results({}, "m", "t", 0, save_dir=tmp_path, file_format="xml")


### PR DESCRIPTION
## What does this PR do?

Adds function save_results to save benchmark results in either JSON or CSV file format at a given save directory.

Additional Key Features:
- Creates the save directory if it doesnt exist yet
- Creates unique and informative filenames based on meta data identifiers (method name, task name, random seed number). 
- If you save more than one run with the same identifiers, it appends a '__runN' suffix so each file stays unique and doesn't get overwritten.

``` python
# Input:
results = {"C2ST": 0.7, "KSD": 0.5}
method = "rej-abc"
task = "two-moons"
seed = 1

# Write JSON
save_results(results, method, task, seed, file_format="json")

# Write CSV
save_results(results, method, task, seed, file_format="csv")
```
``` python
# Output:
# JSON:
{
    "method": "rej-abc",
    "task": "two-moons",
    "seed": 1,
    "timestamp": "2025-04-26T22:19:44",
    "metrics": {
        "C2ST": 0.7,
        "KSD": 0.5
    }
}

# CSV:
method,task,seed,timestamp,C2ST,KSD
rej-abc,two-moons,1,2025-04-26T22:19:44,0.7,0.5
```
## Does this close any issues?

Closes issue #5 (Output result storage and data format)


## Anything else we should know?

This function is still evolving. Future use may uncover additional features to implement - for example, the ability to append new benchmark results to an existing CSV file for easy comparison.


## ✅ Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, no worries—just ask!

- [x] I have read and followed the [contribution guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I have added helpful comments to my code where needed
- [x] I have added tests for new functionality
- [x] (If applicable) I have reported how long new tests run and marked them with `pytest.mark.slow`

**For reviewers:**
- [ ] I have reviewed every file
- [ ] All comments have been addressed