### PR TITLE
61 Fixed Hydra multirun compatibility

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -4,6 +4,15 @@ from src.utils.benchmark_run import run_benchmark
 
 @hydra.main(config_path="configs", config_name="main", version_base="1.3")
 def main(cfg: DictConfig):
+    """Execute benchmark with the given Hydra configuration.
+
+        Args:
+            cfg: Hydra configuration object containing:
+                - task: Task configuration (name, parameters)
+                - inference: Method and simulation parameters
+                - metric: Evaluation metric(s) to compute
+                - random_seed: Random seed for reproducibility
+        """
     run_benchmark(cfg)
 
 if __name__ == "__main__":

--- a/src/utils/benchmark_run.py
+++ b/src/utils/benchmark_run.py
@@ -1,15 +1,9 @@
-import argparse
-import yaml
 import random
-import os
-import csv
 import torch
 
 from src.evaluation.evaluate_inference import evaluate_inference
 from src.inference.Run_Inference import run_inference
 from src.tasks.misspecified_tasks import LikelihoodMisspecifiedTask
-
-
 
 
 # Define a dummy task class


### PR DESCRIPTION
## What does this PR do?

- run.py only calls benchmark_run.py
- Added documentation for run.py
- Fixed metrics saving in evaluate_inference.py

## Does this close any issues?

Fixes https://github.com/sbi-misspecification-benchmark/sbi-misspecification-benchmark/issues/61

## Any relevant code examples, logs, or error messages?

Run with:

`python -m src.run --config-path configs --config-name main`
`python -m src.run --multirun  inference=npe,nle,nre   metric=c2st,ppc  `


## ✅ Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, no worries—just ask!

- [x] I have read and followed the [contribution guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I have added helpful comments to my code where needed
- [ ] I have added tests for new functionality
- [ ] (If applicable) I have reported how long new tests run and marked them with `pytest.mark.slow`

**For reviewers:**
- [ ] I have reviewed every file
- [ ] All comments have been addressed
