### PR TITLE
72 metrics duplication and additional config

### DIFF
--- a/src/configs/metric/c2st_ppc.yaml
+++ b/src/configs/metric/c2st_ppc.yaml
@@ -1,0 +1,1 @@
+name: c2st_ppc

--- a/src/configs/metrics/basic.yaml
+++ b/src/configs/metrics/basic.yaml
@@ -1,3 +1,0 @@
-metrics:
-  - c2st
-  - ppc

--- a/src/metrics/basic_metrics.py
+++ b/src/metrics/basic_metrics.py
@@ -1,7 +1,0 @@
-import numpy as np
-
-def c2st_metric(samples, ground_truth):
-    return np.random.uniform(0, 1)
-
-def ppc_metric(samples, observation):
-    return np.random.uniform(0, 1)


### PR DESCRIPTION
## What does this PR do?

Changes:

- Added additional config c2st_ppc to enable a multirun with both c2st and ppc metrics
- Updated benchmark_run.py to support the new config
- An output CSV file includes columns for both c2st and ppc metrics
- Information about metrics configuration added to YAML_Configuration 
- src/metrics/basic_metrics.py and config/metrics/ were deleted

## Does this close any issues?

Resolves https://github.com/sbi-misspecification-benchmark/sbi-misspecification-benchmark/issues/72

## Any relevant code examples, logs, or error messages?

Run with  `python -m src.run --multirun  metric=c2st_ppc `


## ✅ Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, no worries—just ask!

- [x] I have read and followed the [contribution guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I have added helpful comments to my code where needed
- [ ] I have added tests for new functionality
- [ ] (If applicable) I have reported how long new tests run and marked them with `pytest.mark.slow`

**For reviewers:**
- [ ] I have reviewed every file
- [ ] All comments have been addressed
