### PR TITLE
Fix Handling of Task Parameters (especially Misspecified Task) 

### DIFF
--- a/src/configs/main.yaml
+++ b/src/configs/main.yaml
@@ -1,7 +1,7 @@
 defaults:
   - task: misspecified_likelihood
   - inference: npe
-  - metric: c2st
+  - metric: ppc
   - _self_
 
 random_seed: 86

--- a/src/configs/task/misspecified_likelihood.yaml
+++ b/src/configs/task/misspecified_likelihood.yaml
@@ -1,3 +1,4 @@
 name: misspecified_likelihood
-tau_m: 0.2
-lambda_val: 0.6
+dim : 2
+tau_m: 1.0
+lambda_val: 0.5

--- a/src/tasks/misspecified_tasks.py
+++ b/src/tasks/misspecified_tasks.py
@@ -73,29 +73,29 @@ class LikelihoodMisspecifiedTask:
 
     def __init__(
         self,
-        dim: int = 2,
-        tau_m: float = 2.0,  # Misspecified likelihood variance
-        lambda_val: float = 0.5,  # Mixture weight
+        dim: int,
+        tau_m: float,  # Misspecified likelihood variance
+        lambda_val: float,  # Mixture weight
     ):
         """Initialize the Gaussian misspecified likelihood task.
 
         Args:
             dim (int): Dimensionality of the parameter space
             tau_m (float): Variance factor for the misspecified likelihood
-            lambda_val (float): Mixture weight
+            lambda_val (float): Mixture weight in [0, 1]
         """
-        self.dim = dim
+        self.dim = int(dim)
 
         # misspeciifcation parameters
-        self.tau_m = tau_m
-        self.lambda_val = lambda_val
+        self.tau_m = float(tau_m)
+        self.lambda_val = float(lambda_val)
 
         # prior parameters
-        self.mu_prior = torch.ones(dim)
-        self.sigma_prior = torch.eye(dim)
+        self.mu_prior = torch.ones(self.dim)
+        self.sigma_prior = torch.eye(self.dim)
 
         # Setup ground truth model
-        self.ground_truth = GroundTruthModel(dim=dim)
+        self.ground_truth = GroundTruthModel(dim=self.dim)
 
         # define prior
         self.prior = self.ground_truth.prior_dist
@@ -150,7 +150,7 @@ class LikelihoodMisspecifiedTask:
         return samples.reshape(10_000, self.dim)
 
 
-    def simulator(self, thetas):
+    def simulator(self, thetas:torch.Tensor):
         """Simulate observations x given parameters theta under a misspecified likelihood model.
 
         Args:

--- a/src/utils/benchmark_run.py
+++ b/src/utils/benchmark_run.py
@@ -2,6 +2,7 @@ import random
 import torch
 import os
 import pandas as pd
+from omegaconf import OmegaConf
 
 from src.evaluation.evaluate_inference import evaluate_inference
 from src.inference.Run_Inference import run_inference
@@ -23,7 +24,12 @@ def run_benchmark(config):
     task_name = config.task.name
     if task_name not in task_registry:
         raise ValueError(f"Unknown task: {task_name}. Available: {list(task_registry.keys())}")
-    task = task_registry[task_name]()
+    
+    Task = task_registry[task_name]   # Get the task class from the registry
+    
+    task_kwargs = OmegaConf.to_container(config.task, resolve=True) or {} # Convert Hydra node to a dict
+    task_kwargs.pop("name", None)  # Remove the 'name' key if it exists
+    task = Task(**task_kwargs)  # Initialize the task with the provided parameters
 
     method = config.inference.method.upper()
     num_simulations = config.inference.num_simulations


### PR DESCRIPTION
## What does this PR do?

This PR fixes the handling of task parameters.    
Until now, there were hardcoded default parameters for the Misspecified_likelihood Task what led to the parameters in the config .yaml file being ignored. 

I deleted the default params and added a short logic in `src\utils\benchmark_run.py` so that the keys given in the config reach the task.    
The arguments from the config are now forwarded directly to the task’s constructor.
It does not matter which keys are specified in the config, as they are simply passed as a dictionary on to the task.


