### PR TITLE
Change output of ppc.py to numpy Object instead of toch.tensor

### DIFF
--- a/src/configs/main.yaml
+++ b/src/configs/main.yaml
@@ -1,7 +1,7 @@
 defaults:
   - task: misspecified_likelihood
   - inference: npe
-  - metric: c2st
+  - metric: ppc
   - _self_
 
 random_seed: 86

--- a/src/evaluation/metrics/ppc.py
+++ b/src/evaluation/metrics/ppc.py
@@ -20,10 +20,9 @@ def compute_ppc(posterior_samples, observation, simulator):
 
     # compute the absolute distance between each pair
     l2_distance = torch.norm((observation - simulated_x), dim= -1)
-    # torch.tensor([np.median(l2_distance.numpy()).astype(np.float32)]).item()   # From SBI
-    # mean distance across all samples
+    
 
-    median = torch.median(l2_distance)
+    median = torch.median(l2_distance).numpy()
 
     score = median / (0.5 + median) # to ensure the score is in [0, 1]
 


### PR DESCRIPTION
## What does this PR do?

Fixes the visualization of ppc results.


## Does this close any issues?
Fixes #83 



## Any relevant code examples, logs, or error messages?

Changed the ouput of ppc to a numpy object instead of a torch.tensor so that the visualization script can handle it.

```python 
median = torch.median(l2_distance).numpy()
```

Now the visualization is as it should be.
<img width="290" height="285" alt="{4985A4C6-CF8F-4A60-A4D7-F0B6E8088E01}" src="https://github.com/user-attachments/assets/a7dfe784-1a23-45c9-b2d5-0da3fd5ba3c3" />


## ✅ Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, no worries—just ask!

- [ ] I have read and followed the [contribution guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [ ] I have added helpful comments to my code where needed
- [ ] I have added tests for new functionality
- [ ] (If applicable) I have reported how long new tests run and marked them with `pytest.mark.slow`

**For reviewers:**
- [ ] I have reviewed every file
- [ ] All comments have been addressed